### PR TITLE
[fix] Don't skip hidden dot-directories when walking a directory argument

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -232,6 +232,12 @@ fn file_walker_builder(include_paths: Vec<&String>, include_gitignored: bool) ->
 
     builder.git_ignore(!include_gitignored);
     builder.add_custom_ignore_filename(".rubyfmtignore");
+
+    // WalkBuilder ignores hidden files by default, dropping .rb files under
+    // dot-directories like .buildkite/. Un-hide dotfiles, but keep .git out.
+    builder.hidden(false);
+    builder.filter_entry(|entry| entry.file_name() != OsStr::new(".git"));
+
     builder
 }
 

--- a/tests/cli_interface_test.rs
+++ b/tests/cli_interface_test.rs
@@ -462,6 +462,58 @@ fn test_format_directory_with_changes() {
 }
 
 #[test]
+fn test_format_directory_with_changes_in_hidden_directory() {
+    // Hidden directories should not be skipped when walking a directory argument.
+    let dir = tempdir().unwrap();
+    let dir_name = dir.path().to_str().unwrap().to_owned();
+    create_dir(dir_name.clone() + "/.hidden").unwrap();
+
+    let mut file = tempfile::Builder::new()
+        .prefix("rubyfmt")
+        .suffix(".rb")
+        .tempfile_in(dir_name.clone() + "/.hidden")
+        .unwrap();
+    writeln!(file, "a 1, 2, 3").unwrap();
+
+    Command::cargo_bin("rubyfmt-main")
+        .unwrap()
+        .arg(dir_name)
+        .arg("-i")
+        .assert()
+        .stdout("")
+        .code(0)
+        .success();
+
+    assert_eq!("a(1, 2, 3)\n", read_to_string(file.path()).unwrap());
+}
+
+#[test]
+fn test_format_directory_ignores_git_directory() {
+    // .git should still be skipped even though hidden directories are walked now.
+    let dir = tempdir().unwrap();
+    let dir_name = dir.path().to_str().unwrap().to_owned();
+    create_dir(dir_name.clone() + "/.git").unwrap();
+
+    let mut file = tempfile::Builder::new()
+        .prefix("rubyfmt")
+        .suffix(".rb")
+        .tempfile_in(dir_name.clone() + "/.git")
+        .unwrap();
+    writeln!(file, "a 1, 2, 3").unwrap();
+
+    Command::cargo_bin("rubyfmt-main")
+        .unwrap()
+        .arg(dir_name)
+        .arg("-i")
+        .assert()
+        .stdout("")
+        .code(0)
+        .success();
+
+    assert_eq!("a 1, 2, 3\n", read_to_string(file.path()).unwrap());
+}
+
+#[test]
 fn format_input_file_with_changes() {
     let mut file_one = NamedTempFile::new().unwrap();
     writeln!(file_one, "a 1, 2, 3").unwrap();


### PR DESCRIPTION
Fixes #947.

`file_walker_builder` builds an `ignore::WalkBuilder` for directory arguments but never disables the crate's default hidden-file skip, so `rubyfmt --check .` (or `-i .`) never visits `.rb` files under dot-directories like `.buildkite/` or `.github/` — even when they're tracked in git and not excluded by any `.gitignore`/`.rubyfmtignore` pattern. Passing an explicit file path bypasses the walker entirely and is unaffected, which is what made this easy to miss: `rubyfmt --check .buildkite/pipeline.rb` finds problems that `rubyfmt --check .` silently skips.

## Fix

- `builder.hidden(false)` so the walk no longer treats dotfiles/dot-directories as ignored-by-default.
- `builder.filter_entry(...)` to explicitly keep `.git` excluded, since un-hiding would otherwise walk into it too.

`.gitignore`/`.rubyfmtignore` handling is untouched — both still exclude the same paths they did before, for hidden and non-hidden files alike.

## Testing

- Added `test_format_directory_with_changes_in_hidden_directory`: a `.rb` file under a hidden directory gets formatted in-place when the parent directory is passed. Confirmed this fails without the fix (`assertion left == right failed`, file unmodified).
- Added `test_format_directory_ignores_git_directory`: a `.rb` file under `.git/` is still left untouched.
- `cargo test`: 460 passed, 0 failed.
- `cargo clippy`, `cargo fmt --check`, `make lint`: clean.
